### PR TITLE
add mysql port setting

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -49,10 +49,11 @@ class Installer extends Command
         $name = $input->getArgument('name') ? $input->getArgument('name') : 'photoncms';
 
         $hostname = $this->askForHost($input, $output);
+        $port = $this->askForPort($input, $output);
         $username = $this->askForUsername($input, $output);
         $password = $this->askForPassword($input, $output);
 
-        if(!$this->testDbConnection($input, $output, $username, $password, $name, $hostname)) {
+        if(!$this->testDbConnection($input, $output, $username, $password, $name, $hostname, $port)) {
             $output->writeln('<error>...Connecting to database failed</error>');
             return false;
         }
@@ -97,6 +98,7 @@ class Installer extends Command
 
         $this->setEnvironmentValue("DB_DATABASE", $name, $directory);
         $this->setEnvironmentValue("DB_HOST", $hostname, $directory);
+        $this->setEnvironmentValue("DB_PORT", $port, $directory);
         $this->setEnvironmentValue("DB_USERNAME", $username, $directory);
         $this->setEnvironmentValue("DB_PASSWORD", $password, $directory);
         $output->writeln('<info>...updated .env file</info>');
@@ -272,6 +274,22 @@ class Installer extends Command
     }
 
     /**
+     * Prompt user for their db port.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function askForPort($input, $output)
+    {
+        $questionHelper = new QuestionHelper();
+        $question = new Question('<info>...What is your mysql port? [3306]</info>  ', 3306);
+        $port = $questionHelper->ask($input, $output, $question);
+
+        return $port;
+    }
+
+    /**
      * Prompt user for their db username.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
@@ -330,13 +348,13 @@ class Installer extends Command
         return false;
     }
 
-    protected function testDbConnection($input, $output, $username, $password, $database, $hostname)
+    protected function testDbConnection($input, $output, $username, $password, $database, $hostname, $port)
     {
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
         // test connection, if invalid credentials return false
         try {
-            $connection = mysqli_connect($hostname, $username, $password);
+            $connection = mysqli_connect($hostname, $username, $password, null, $port);
         } catch (\mysqli_sql_exception $e) {
             return false;
         }


### PR DESCRIPTION
since my local environment using docker, i used several database connections. i used port 3307 instead of the default one (3306).

this pull request add additional setting to ask user to set their custom database port.

**before:** 
`➜ photon new photon2
...What is your mysql hostname? [localhost]
...What is your mysql port? [3306]
...What is your mysql username? [root]
...What is your mysql password? []
...Connecting to database failed`

After:
`➜ photon new photon2
...What is your mysql hostname? [localhost]  0.0.0.0
...What is your mysql port? [3306]  3307
...What is your mysql username? [root]root
...What is your mysql password? []
...Crafting application
No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 110 installs, 0 updates, 0 removals
  - Locking aws/aws-sdk-php (3.179.2)
  - Locking barryvdh/laravel-dompdf (v0.8.7)
  - Locking baum/baum (1.1.1)
  - Locking brozot/laravel-fcm (1.3.1)
  - Locking cyvelnet/laravel5-fractal (v2.4.2)
  - Locking doctrine/cache (1.11.0)`



